### PR TITLE
Add a Twitter archive page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <li><a href="https://github.com/python-in-astronomy/PythonAstronomy_links">Useful links</a> shared during the workshop
           <li>Blog posts by <a href="http://pbarmby.github.io">Pauline Barmby</a> (<a href="http://pbarmby.github.io/2015/04/20/Python-in-Astronomy-Day-1.html">Day 1</a>, <a href="http://pbarmby.github.io/2015/04/21/Python-in-Astronomy-Day-2.html"> 2</a>, <a href="http://pbarmby.github.io/2015/04/22/Python-in-Astronomy-Day-3.html"> 3</a>, <a href="http://pbarmby.github.io/2015/04/23/Python-in-Astronomy-Day-4.html"> 4</a>, <a href="http://pbarmby.github.io/2015/04/24/Python-in-Astronomy-Day-5.html"> 5</a>, <a href="http://pbarmby.github.io/2015/04/30/Python-in-Astronomy-review.html">Summary</a>) and <a href="http://thespacetimebox.com">Antonio Martin-Carrillo</a> (<a href="http://thespacetimebox.com/2015/04/20/python-in-astronomy-day-1/">Day 1</a>, <a href="http://thespacetimebox.com/2015/04/21/python-in-astronomy-day-2/">2</a>, <a href="http://thespacetimebox.com/2015/04/22/python-in-astronomy-day-3/">3</a>, <a href="http://thespacetimebox.com/2015/04/23/python-in-astronomy-day-4/">4</a>, <a href="http://thespacetimebox.com/2015/04/24/python-in-astronomy-day-5/">5</a>)
           <li>Photos from <a href="https://plus.google.com/u/0/photos/+PeterTeuben/albums/6141280578679475185">Peter Teuben</a> and <a href="https://www.flickr.com/photos/thomasrobitaille/sets/72157653142282004">Tom Robitaille</a>.
-          <li>Twitter archive for the workshop hashtag: #pyastro15 (coming soon)
+          <li><a href="twitter-archive.html">Twitter archive</a> for the workshop hashtag: #pyastro15
         </ul>
         
         <h3>Details</h3>

--- a/twitter-archive.html
+++ b/twitter-archive.html
@@ -1,0 +1,449 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<html>
+  <head>
+    <link href='http://python-in-astronomy.github.io/style.css' rel='stylesheet' type="text/css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700' rel='stylesheet' type='text/css'>
+    <title>Python in Astronomy Lorentz Centre Workshop - 20-24 April 2015</title>
+  </head>
+  <body>
+    <div id="content">
+      <h1>
+        Python in Astronomy
+      </h1>
+      <h2>
+        20-24 April 2015, Lorentz Center, Leiden
+      </h2><br>
+      <img width="75" src='http://python-in-astronomy.github.io/python-logo-generic.png' alt='python logo'><br>
+      <div class="about">
+        <p>
+          During the conference, nearly 1500 messages were posted on Twitter
+          which included the hashtag
+          <a href="https://twitter.com/search?q=%23pyastro15">#pyastro15</a>. On this page we present a flavour of the social activity
+          by displaying, in chronological order, the ~100 "most popular" tweets
+          which were retweeted or favourited at least five times.
+        </p>
+      </div>
+
+      <div class="about">
+        <h2>The #pyastro15 Twitter Archive</h2>
+        <ul>
+          <li><a href="#before">Before the workshop</a></li>
+          <li><a href="#day-1">Day 1: 20 April 2015</a></li>
+          <li><a href="#day-2">Day 2: 21 April 2015</a></li>
+          <li><a href="#day-3">Day 3: 22 April 2015</a></li>
+          <li><a href="#day-4">Day 4: 23 April 2015</a></li>
+          <li><a href="#day-5">Day 5: 24 April 2015</a></li>
+          <li><a href="#after">After the workshop</a></li>
+        </ul>
+
+        <h3 id="before">Before the workshop</h3>
+        <div id="tweets-before"></div>
+
+        <h3 id="day-1">Day 1: 20 April 2015</h3>
+        <div id="tweets-day-1"></div>
+
+        <h3 id="day-2">Day 2: 21 April 2015</h3>
+        <div id="tweets-day-2"></div>
+
+        <h3 id="day-3">Day 3: 22 April 2015</h3>
+        <div id="tweets-day-3"></div>
+
+        <h3 id="day-4">Day 4: 23 April 2015</h3>
+        <div id="tweets-day-4"></div>
+
+        <h3 id="day-5">Day 5: 24 April 2015</h3>
+        <div id="tweets-day-5"></div>
+
+        <h3>After the workshop</h3>
+        <div id="tweets-after"></div>
+
+      </div>
+</div>
+
+  </body>
+
+<script>
+// First, load the widgets.js file asynchronously
+window.twttr = (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0],
+    t = window.twttr || {};
+  if (d.getElementById(id)) return;
+  js = d.createElement(s);
+  js.id = id;
+  js.src = "https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+ 
+  t._e = [];
+  t.ready = function(f) {
+    t._e.push(f);
+  };
+ 
+  return t;
+}(document, "script", "twitter-wjs"));
+
+// Wait for the asynchronous resources to load
+twttr.ready(function (twttr) {
+  // Now add the tweets
+  twttr.widgets.createTweet("589413425954029568",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589679825163530240",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589747741049430016",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589771961926078465",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589792648862507010",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589793113490776064",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589836946656141314",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("589859204233568256",
+                            document.getElementById('tweets-before'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590063964488359936",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590066690005827584",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590067585003167744",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590075611663757312",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590080740810981376",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590085251227082752",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590086463372525568",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590086742918766592",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590088325459025921",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590089989083553792",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590091706768433153",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590092450024271872",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590093723972849665",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590096606101372928",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590154750383026177",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590166600604635136",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590234555803508736",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590269306534920192",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590424827565047811",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590425702870216704",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590427479904559104",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590429729854980096",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590430588378730497",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590431055615635457",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590432114824318976",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590434608577191937",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590445731758084096",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590449369805099008",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590450124976959488",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590450371409027072",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590453914421616640",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590494081769418752",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590501164178870272",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590513274283786241",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590521488437940225",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590535740234342400",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590564144610418689",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590599189022801922",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590636440893136896",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590781360949846016",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590786813607997440",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590794270983991296",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590802555380314112",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590805694523248642",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590808350599815168",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590810293187522560",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590811973123702786",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590817943778414592",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590818846640046080",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590827100216627200",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590844067464015872",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590854679439024129",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590868256036155392",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590904214668337152",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590969434241662976",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("590976032053841920",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591143714153746432",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591146711009099776",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591146726796431360",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591152171833503744",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591152178573770752",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591166763695546368",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591169891333443584",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591170583599124481",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591171163398742016",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591172930928775168",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591181603134709760",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591222059985932288",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591225239083810819",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591265815732875264",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591266798214995969",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344294893637633",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344512250880002",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344513949523968",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344517154021380",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344519855083521",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344580022272001",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591344584464195585",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591345156827312128",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591504638760726528",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591512820614725632",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591514433530306560",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591515759001604096",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591518647283245056",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591519040436338688",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591530045006569472",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591530356752437248",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591534660695564290",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591536121630294016",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591539160437153792",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591540119624142848",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591544992209973249",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591545198381027328",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591545321227943936",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591545724808069120",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591547217711857664",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591583376999579648",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591598188190040064",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591602361895878656",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591606649451839488",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591625638248730624",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591660628319850496",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591665151188795393",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591689864275468288",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591694789374046208",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591698576671113216",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591709785793388544",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591728975011028997",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591830251354861568",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("591917004593987584",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("592000094964228096",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+});
+</script>
+
+</html>
+


### PR DESCRIPTION
This PR adds a page which displays the 100 "most popular" messages tweeted during the workshop, with "most popular" defined as having at least 5 favourites or 5 retweets.

You can see the page rendered here: http://htmlpreview.github.io/?https://github.com/barentsen/python-in-astronomy.github.io/blob/twitter-archive/twitter-archive.html

Let me know what you think?
