### PR TITLE
Update code of conduct for 2016

### DIFF
--- a/2016/code-of-conduct.html
+++ b/2016/code-of-conduct.html
@@ -4,16 +4,13 @@
   <head>
     <link href='style.css' rel='stylesheet' type="text/css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700' rel='stylesheet' type='text/css'>
-    <title>Python in Astronomy Workshop, University of Washington - 21-25 March 2016</title>
+    <title>Python in Astronomy Workshop Code of Conduct</title>
   </head>
   <body>
     <div id="content">
       <h1>
-        Python in Astronomy
+        Python in Astronomy Workshop Code of Conduct
       </h1>
-      <h2>
-        21-25 March 2016, University of Washington, Seattle
-      </h2><br>
       <div class='about'>
 
 <p>
@@ -22,8 +19,8 @@
   member of the workshop and want all attendees to have an enjoyable and
   fulfilling experience. Accordingly, all attendees are expected to show
   respect and courtesy to other attendees throughout the workshop and to abide
-  by the following Code of Conduct. Please bring any issues to the confidential
-  attention of the workshop organizers, and thank you for helping make this a
+  by the following Code of Conduct. Any issues can be brought to the confidential
+  attention of the workshop organizers (including via e-mail to <a href="mailto:python-in-astronomy-soc@gmail.com?Subject=Code%20of%20Conduct%20Violation">python-in-astronomy-soc@gmail.com</a>), and thank you for helping make this a
   welcoming, friendly event for all.
 </p>
 
@@ -31,39 +28,36 @@
   Code of Conduct
 </h2>
 
+    <p>The community of participants of Python in Astronomy Workshops is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. We expect everyone in our community to follow these guidelines when interacting with others both inside and outside of our community. Our goal is to keep ours a positive, inclusive, successful, and growing community.</p>
+
+    <p>As members of the community,</p>
+
+    <ul>
+    <li>We pledge to treat all people with respect and provide a harassment- and bullying-free environment, regardless of sex, sexual orientation and/or gender identity, disability, physical appearance, body size, race, nationality, ethnicity, and religion. In particular, sexual language and imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.</li>
+    <li>We pledge to respect the work of others by recognizing acknowledgment/citation requests of original authors. As authors, we pledge to be explicit about how we want our own work to be cited or acknowledged.</li>
+    <li>We pledge to welcome those interested in joining the community, and realize that including people with a variety of opinions and backgrounds will only serve to enrich our community. In particular, discussions relating to pros/cons of various technologies, programming languages, and so on are welcome, but these should be done with respect, taking proactive measure to ensure that all participants are heard and feel confident that they can freely express their opinions.</li>
+    <li>We pledge to welcome questions and answer them respectfully, paying particular attention to those new to the community. </li>
+    <li>We pledge to be conscientious of the perceptions of the wider community and to respond to criticism respectfully. We will strive to model behaviors that encourage productive debate and disagreement, both within our community and where we are criticized. We will treat those outside our community with the same respect as people within our community.</li>
+    <li>We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct.  We will take action when members of our community violate this code such as notifying a workshop organizer, emailing  <a href="mailto:python-in-astronomy-soc@gmail.com?Subject=Code%20of%20Conduct%20Violation">python-in-astronomy-soc@gmail.com</a>, or talking privately with the person.
+    </li>
+    </ul>
+
+    <p>This code of conduct applies to all community situations online and offline, including the conference itself, mailing lists, forums, social media, social events associates with the conference, and one-to-one interactions.</p>
+
+    <p>
+    Participants asked to stop any harassing behavior are expected to comply
+    immediately. Attendees violating these rules may be asked to leave the event at
+    the sole discretion of the conference organizers.
+    </p>
+
+<br>
 <p>
-  Python in Astronomy will be a harassment-free environment for everyone,
-  regardless of gender, sexual orientation, disability, physical appearance,
-  body size, race, nationality, religion, or choice of Python 2 versus 3.
-<ul>
-  <li>Harassment includes offensive verbal comments related to gender, sexual
-      orientation, disability, physical appearance, body size, race, religion,
-      sexual images in public spaces, deliberate intimidation, stalking,
-      following, harassing photography or recording, sustained disruption of
-      talks or other events, inappropriate physical contact, and unwelcome
-      sexual attention.
-  <li>All communication should be appropriate for a professional audience
-      including people of many different backgrounds. Sexual language and
-      imagery is not appropriate for any event.
-  <li>Be kind to others. Do not insult or put down other attendees.
-  <li>Behave professionally. Remember that harassment and sexist, racist, or
-      exclusionary jokes are not appropriate.
-</ul>
+  This code of conduct has been adapted from the <a href="http://www.astropy.org/about.html#codeofconduct"> Astropy Community Code of Conduct</a>.
 </p>
 
-<p>
-Participants asked to stop any harassing behavior are expected to comply
-immediately. Attendees violating these rules may be asked to leave the event at
-the sole discretion of the conference organizers.
-</p>
 
+<p class="center"><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /></p>
 
-<p>
-  This code of conduct is adapted from
-  <a href="http://software-carpentry.org/conduct.html">
-    http://software-carpentry.org/conduct.html
-  </a>
-</p>
 
   </div>
 </div>

--- a/2016/index.html
+++ b/2016/index.html
@@ -91,9 +91,7 @@
         <h3>Details</h3>
         <p>During the workshop, we require participants to follow the
         code of conduct for the workshop which can be found <a target="_blank"
-        href='code-of-conduct.html'>here</a>, and to also abide by the
-        <a target="_blank" href="https://www.python.org/psf/codeofconduct/">Python
-        Community Code of Conduct</a>. If you have any questions about
+        href='code-of-conduct.html'>here</a>. If you have any questions about
         the workshop, you can reach the SOC at <a href="mailto:python-in-astronomy-soc@googlegroups.com">python-in-astronomy-soc@googlegroups.com</a>
         </p>
         <p>

--- a/2016/index.html
+++ b/2016/index.html
@@ -92,7 +92,7 @@
         <p>During the workshop, we require participants to follow the
         code of conduct for the workshop which can be found <a target="_blank"
         href='code-of-conduct.html'>here</a>. If you have any questions about
-        the workshop, you can reach the SOC at <a href="mailto:python-in-astronomy-soc@googlegroups.com">python-in-astronomy-soc@googlegroups.com</a>
+        the workshop, you can reach the SOC at <a href="mailto:python-in-astronomy-soc@gmail.com">python-in-astronomy-soc@gmail.com</a>
         </p>
         <p>
           The workshop is hosted by the University of Washington <a


### PR DESCRIPTION
This updates the code of conduct on the web page to be adapted from the Astropy Community CoC (which was written in large part from an unconference session in PIA15).

This also updates the email address on the 2016 index page.
