### PR TITLE
Add a page showing the most popular #PyAstro16 tweets

### DIFF
--- a/2016/twitter-archive.html
+++ b/2016/twitter-archive.html
@@ -1,0 +1,585 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
+"http://www.w3.org/TR/html4/strict.dtd">
+
+<html>
+  <head>
+    <link href='http://python-in-astronomy.github.io/2016/style.css' rel='stylesheet' type="text/css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700' rel='stylesheet' type='text/css'>
+    <title>Python in Astronomy - 21-25 March 2016</title>
+    <link rel="icon" 
+      type="image/png" 
+      href="http://python-in-astronomy.github.io/2016/astropython.png">
+  </head>
+  <body>
+    <div id="content">
+
+     <h1>
+        Python in Astronomy 2016
+      </h1>
+      <h2>
+        21-25 March 2016, University of Washington, Seattle
+      </h2><br>
+      <img width="100" src='http://python-in-astronomy.github.io/2016/python-logo-generic.png'><br>
+
+    <div class="about">
+        <p>
+          During the conference, nearly 900 messages were posted on Twitter
+          which included the hashtag
+          <a href="https://twitter.com/search?q=%23pyastro16">#pyastro16</a>.
+          On this page we present an overview of the social activity
+          by displaying, in chronological order, the 164 "most popular" tweets
+          which were retweeted or favorited at least five times.
+        </p>
+      </div>
+
+      <div class="about">
+        <h2>The #PyAstro16 Twitter Archive</h2>
+        <ul>
+          <li><a href="#day-1">Day 1: 21 March 2016</a></li>
+          <li><a href="#day-2">Day 2: 22 March 2016</a></li>
+          <li><a href="#day-3">Day 3: 23 March 2016</a></li>
+          <li><a href="#day-4">Day 4: 24 March 2016</a></li>
+          <li><a href="#day-5">Day 5: 25 March 2016</a></li>
+          <li><a href="#after">After the meeting</a></li>
+        </ul>
+
+        <h3 id="day-1">Day 1: 21 March 2016</h3>
+        <div id="tweets-day-1"></div>
+
+        <h3 id="day-2">Day 2: 22 March 2016</h3>
+        <div id="tweets-day-2"></div>
+
+        <h3 id="day-3">Day 3: 23 March 2016</h3>
+        <div id="tweets-day-3"></div>
+
+        <h3 id="day-4">Day 4: 24 March 2016</h3>
+        <div id="tweets-day-4"></div>
+
+        <h3 id="day-5">Day 5: 25 March 2016</h3>
+        <div id="tweets-day-5"></div>
+
+        <h3 id="after">After the meeting</h3>
+        <div id="tweets-after"></div>
+
+      </div>
+</div>
+
+<script>
+// First, load the widgets.js file asynchronously
+window.twttr = (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0],
+    t = window.twttr || {};
+  if (d.getElementById(id)) return;
+  js = d.createElement(s);
+  js.id = id;
+  js.src = "https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+ 
+  t._e = [];
+  t.ready = function(f) {
+    t._e.push(f);
+  };
+ 
+  return t;
+}(document, "script", "twitter-wjs"));
+
+// Wait for the asynchronous resources to load
+twttr.ready(function (twttr) {
+  // Now add the tweets
+  twttr.widgets.createTweet("711883107515826176",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711947096518053888",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711947138477854724",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711948249611968512",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711949873285693440",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711951460494213121",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711952640561717251",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711953829319680000",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711954047876472832",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711954359760715776",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711954722693849090",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711954856978690050",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711957120300679168",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711960551740411904",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711961689537708033",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711962162902634498",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711962442318807040",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711962452640923648",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711963192834961408",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711965165185437696",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711966962796994560",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711967228980109313",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711967619071418369",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711968566015356933",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711970488528936961",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711973865316962304",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711984610549243904",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711985473934139392",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711986383510835200",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711989995754508289",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711990811102044160",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711991689116852225",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711991921741209602",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711993100890087424",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711994014489153537",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("711997286792847360",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712028536396259328",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712031781965467648",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712032155543719941",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712034584712630273",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712035101866135553",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712079618665152512",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712101889463033856",
+                            document.getElementById('tweets-day-1'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712287401591361536",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712308580808921088",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712308937865842688",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712313535276011521",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712313625189294080",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712315268676984833",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712316039082549248",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712316593070407680",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712316704643100672",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712319864719822848",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712321231203110912",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712323831508013056",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712325169490976768",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712338595244335104",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712373046074474496",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712387778462355456",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712389846094848000",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712399365038432256",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712413196062076929",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712418927708471297",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712419383532892160",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712440035346292736",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712442387448991746",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712443691038736384",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712480176144121856",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712501987737112576",
+                            document.getElementById('tweets-day-2'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712607027785252864",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712664653055135744",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712670866455207936",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712673214346821633",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712673812148408321",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712674142571499520",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712674198980657152",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712681007254614016",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712681871595819009",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712683809410396160",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712685256931848193",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712686675869044736",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712686756999471108",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712686931440590848",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712687215118127104",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712688293754744833",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712690834647306240",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712690950452031488",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712700983814402048",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712701194867609600",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712702335160422400",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712706636511457280",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712706684389429249",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712706785526689792",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712709603734073344",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712710183449853952",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712712427855425536",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712712637709045760",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712713049262522368",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712714144726650880",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712714240109318144",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712717247035219968",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712717914055380997",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712720258457440256",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712720534409076736",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712720715795922945",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712720948936318977",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712721913840152577",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712722194342608897",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712722699756253184",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712723535588757505",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712723963021893632",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712762083104858113",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712774531820040192",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712795223441604612",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712799008016568320",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712838664703750144",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("712864740167573505",
+                            document.getElementById('tweets-day-3'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713007257135423488",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713038416439476225",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713055508257636352",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713098680866213888",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713118558549479424",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713149525557252097",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713156666825441280",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713203708759150592",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713204217079402496",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713205302355603456",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713207688805486592",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713217423894142977",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713244526513532928",
+                            document.getElementById('tweets-day-4'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713405209221804032",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713408708936540161",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713409101347295232",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713413985505153024",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713429301639536640",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713429469705297921",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713431347453243392",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713433355233005568",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713433693570727937",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713433933040340993",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713435112449249280",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713440334026387457",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713441470548541440",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713446680100601856",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713459317110910980",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713461927133978626",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713465570293784576",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713472536630046720",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713492936697118724",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713494674648903681",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713538395247513600",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713541194421129217",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713548472020914176",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713550330584240128",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713584130605211650",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713589958041206784",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713631851626102784",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713652099439939585",
+                            document.getElementById('tweets-day-5'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713744052433215488",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("713850523154124800",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("714192488769019904",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("714194692464779264",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("714221427419774977",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  twttr.widgets.createTweet("714333835832328192",
+                            document.getElementById('tweets-after'),
+                            { theme: 'dark' });
+  });
+</script>
+
+</body>
+</html>

--- a/2016/twitter-archive.html
+++ b/2016/twitter-archive.html
@@ -3,12 +3,12 @@
 
 <html>
   <head>
-    <link href='http://python-in-astronomy.github.io/2016/style.css' rel='stylesheet' type="text/css">
+    <link href='style.css' rel='stylesheet' type="text/css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700' rel='stylesheet' type='text/css'>
     <title>Python in Astronomy - 21-25 March 2016</title>
     <link rel="icon" 
       type="image/png" 
-      href="http://python-in-astronomy.github.io/2016/astropython.png">
+      href="astropython.png">
   </head>
   <body>
     <div id="content">
@@ -19,7 +19,7 @@
       <h2>
         21-25 March 2016, University of Washington, Seattle
       </h2><br>
-      <img width="100" src='http://python-in-astronomy.github.io/2016/python-logo-generic.png'><br>
+      <img width="100" src='python-logo-generic.png'><br>
 
     <div class="about">
         <p>
@@ -28,7 +28,7 @@
           <a href="https://twitter.com/search?q=%23pyastro16">#pyastro16</a>.
           On this page we present an overview of the social activity
           by displaying, in chronological order, the 164 "most popular" tweets
-          which were retweeted or favorited at least five times.
+          which were retweeted or favourited more than five times.
         </p>
       </div>
 


### PR DESCRIPTION
This PR adds a page showing all #PyAstro16 tweets that were favorited or retweeted at least five times.

This is intended to be part of the online unproceedings, and is identical to a [similar page](http://python-in-astronomy.github.io/2015/twitter-archive.html) created for last year's edition.

The script used to create this page is https://github.com/barentsen/pyastro-tweets/blob/master/2-create-html-page.py
